### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ required to execute ANTLR.
 
 Install the [.Net core](https://dotnet.microsoft.com/) sdk.
 and then exexcute
-    ```
+
     dotnet build Antlr/
     dotnet build "asn1scc.sln"
-    ```
+    
 and the compiler will be built.
 
 Under Windows, you can also open open `asn1scc.sln` and build the `asn1scc` project (right-click/build)


### PR DESCRIPTION
Hi Thanassis,

Is this better?

---


Fix formatting: in the rendered markdown by Github, the commands appear on one line, which is misleading and gives an error when copy pasted directly. Fixing it so they appear on two lines and can be copy pasted without error.