### PR TITLE
Optimize Code Generation by eliminating Unused Functions

### DIFF
--- a/BackendAst/DAstACN.fs
+++ b/BackendAst/DAstACN.fs
@@ -2535,6 +2535,10 @@ let createReferenceFunction (r:Asn1AcnAst.AstRoot) (deps:Asn1AcnAst.AcnInsertedF
                 | None -> us
                 | Some tasInfo ->
                     let caller = {Caller.typeId = tasInfo; funcType=AcnEncDecFunctionType}
+                        //match List.rev t.referencedBy with
+                        //| [] -> {Caller.typeId = tasInfo; funcType=AcnEncDecFunctionType}
+                        //| hd::_ -> {Caller.typeId = {TypeAssignmentInfo.modName = hd.modName; tasName=hd.tasName}; funcType=AcnEncDecFunctionType}
+                        
                     let callee = {Callee.typeId = {TypeAssignmentInfo.modName = o.modName.Value; tasName=o.tasName.Value} ; funcType=AcnEncDecFunctionType}
                     addFunctionCallToState us caller callee
 

--- a/BackendAst/DAstACN.fs
+++ b/BackendAst/DAstACN.fs
@@ -330,7 +330,14 @@ let private createAcnFunction (r: Asn1AcnAst.AstRoot)
 
                 let errCodStr = errCodes |> List.map(fun x -> EmitTypeAssignment_def_err_code x.errCodeName (BigInteger x.errCodeValue) x.comment) |> List.distinct
                 let funcDef = Some(EmitTypeAssignment_primitive_def varName sStar funcName  (typeDefinition.longTypedefName2 lm.lg.hasModules) errCodStr (t.acnMaxSizeInBits = 0I) nMaxBytesInACN ( t.acnMaxSizeInBits) prms soSparkAnnotations codec)
-                func, funcDef, auxiliaries, icdResult, ns1a
+                let ns2a =
+                    match t.id.topLevelTas with
+                    | None -> ns1a
+                    | Some tasInfo ->
+                        let caller = {Caller.typeId = tasInfo; funcType= UperEncDecFunctionType}
+                        let callee = {Callee.typeId = tasInfo; funcType=IsValidFunctionType}
+                        addFunctionCallToState ns1a caller callee
+                func, funcDef, auxiliaries, icdResult, ns2a
 
     let icdAux, ns3 =
         match icdResult with
@@ -2523,9 +2530,16 @@ let createReferenceFunction (r:Asn1AcnAst.AstRoot) (deps:Asn1AcnAst.AcnInsertedF
                 let funcBodyContent = callBaseTypeFunc lm pp baseFncName codec
                 Some ({AcnFuncBodyResult.funcBody = funcBodyContent; errCodes = [errCode]; localVariables = []; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=resultExpr; auxiliaries=[]; icdResult = icd}), us)
 
+            let ns =
+                match t.id.topLevelTas with
+                | None -> us
+                | Some tasInfo ->
+                    let caller = {Caller.typeId = tasInfo; funcType=AcnEncDecFunctionType}
+                    let callee = {Callee.typeId = {TypeAssignmentInfo.modName = o.modName.Value; tasName=o.tasName.Value} ; funcType=AcnEncDecFunctionType}
+                    addFunctionCallToState us caller callee
 
             let soSparkAnnotations = Some(sparkAnnotations lm (typeDefinition.longTypedefName2 lm.lg.hasModules) codec)
-            let a, ns = createAcnFunction r deps lm codec t typeDefinition  isValidFunc funcBody (fun atc -> true) soSparkAnnotations [] us
+            let a, ns = createAcnFunction r deps lm codec t typeDefinition  isValidFunc funcBody (fun atc -> true) soSparkAnnotations [] ns
             Some a, ns
 
     | Some encOptions ->

--- a/BackendAst/DAstEqual.fs
+++ b/BackendAst/DAstEqual.fs
@@ -346,7 +346,7 @@ let createReferenceTypeEqualFunction (r:Asn1AcnAst.AstRoot) (lm:LanguageMacros) 
         let ns =
             match t.id.topLevelTas with
             | None -> 
-                printfn "No type assignment info for %A" t.id
+                //printfn "No type assignment info for %A" t.id
                 us
             | Some tasInfo ->
                 let caller = {Caller.typeId = tasInfo; funcType=EqualFunctionType}

--- a/BackendAst/DAstInitialize.fs
+++ b/BackendAst/DAstInitialize.fs
@@ -1253,7 +1253,7 @@ let createReferenceType (r:Asn1AcnAst.AstRoot) (lm:LanguageMacros) (t:Asn1AcnAst
             let ns =
                 match t.id.topLevelTas with
                 | None -> 
-                    printfn "No type assignment info for %A" t.id
+                    //printfn "No type assignment info for %A" t.id
                     us
                 | Some tasInfo ->
                     let caller = {Caller.typeId = tasInfo; funcType=InitFunctionType}

--- a/BackendAst/DastValidate2.fs
+++ b/BackendAst/DastValidate2.fs
@@ -1033,6 +1033,16 @@ let createReferenceTypeFunction (r:Asn1AcnAst.AstRoot) (l:LanguageMacros) (t:Asn
             | false -> moduleName + "." + baseTypeDefinitionName + "_IsConstraintValid"
 
 
+    let ns =
+        match resolvedType.isValidFunction with
+        | Some _    ->
+            match t.id.topLevelTas with
+            | None -> us
+            | Some tasInfo ->
+                let caller = {Caller.typeId = tasInfo; funcType=IsValidFunctionType}
+                let callee = {Callee.typeId = {TypeAssignmentInfo.modName = o.modName.Value; tasName=o.tasName.Value} ; funcType=IsValidFunctionType}
+                addFunctionCallToState us caller callee
+        | None      -> us
     let funBody (errCode: ErrorCode) (p:CallerScope) =
         let with_component_check, lv2 =
             convertMultipleVCBsToStatementAndSetErrorCode l p errCode vcbs |>
@@ -1051,6 +1061,6 @@ let createReferenceTypeFunction (r:Asn1AcnAst.AstRoot) (l:LanguageMacros) (t:Asn
 
     let errorCodeComment = o.refCons |> List.map(fun z -> z.ASN1) |> Seq.StrJoin ""
 
-    createIsValidFunction r l t funBody  typeDefinition [] [] [] [] (Some errorCodeComment) us
+    createIsValidFunction r l t funBody  typeDefinition [] [] [] [] (Some errorCodeComment) ns
 
 

--- a/BackendAst/GenerateFiles.fs
+++ b/BackendAst/GenerateFiles.fs
@@ -316,14 +316,18 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
                 for tas in tases do
                     let typeAssignmentInfo = tas.Type.id.tasInfo.Value
                     let f cl = {Caller.typeId = typeAssignmentInfo; funcType = cl}
-                    let reqUPER = r.callersSet |> Set.contains (f UperEncDecFunctionType)
-                    let reqACN = r.callersSet |> Set.contains (f AcnEncDecFunctionType)
+                    let reqUPER = 
+                        r.args.encodings |> Seq.exists ((=) CommonTypes.UPER)
+                        && r.callersSet |> Set.contains (f UperEncDecFunctionType)
+                    let reqACN = 
+                        r.args.encodings |> Seq.exists ((=) CommonTypes.ACN)
+                        && r.callersSet |> Set.contains (f AcnEncDecFunctionType)
 
-                    if reqUPER && r.args.encodings |> Seq.exists ((=) CommonTypes.UPER) then
+                    if reqUPER then
                         yield (tas.Type.uperEncDecTestFunc |> Option.map (fun z -> z.func))
                     if r.args.encodings |> Seq.exists ((=) CommonTypes.XER) then
                         yield (tas.Type.xerEncDecTestFunc |> Option.map (fun z -> z.func))
-                    if reqACN && r.args.encodings |> Seq.exists ((=) CommonTypes.ACN) then
+                    if reqACN  then
                         yield (tas.Type.acnEncDecTestFunc |> Option.map (fun z -> z.func))
                 } |> Seq.choose id |> Seq.toList
 

--- a/BackendAst/GenerateFiles.fs
+++ b/BackendAst/GenerateFiles.fs
@@ -95,16 +95,23 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
     let typeDefs =
         tases |>
         List.map(fun tas ->
+            let typeAssignmentInfo = tas.Type.id.tasInfo.Value
+            let f cl = {Caller.typeId = typeAssignmentInfo; funcType = cl}
+
             let type_definition =
                 match tas.Type.typeDefinitionOrReference with
                 | TypeDefinition td -> td.typedefBody ()
                 | ReferenceToExistingDefinition _   -> raise(BugErrorException "Type Assignment with no Type Definition")
             let init_def        =
-                match lm.lg.initMethod with
-                | Procedure ->
-                    Some(getInitializationFunctions tas.Type.initFunction |> List.choose( fun i_f -> i_f.initProcedure) |> List.map(fun c -> c.def) |> Seq.StrJoin "\n" )
-                | Function ->
-                    Some(getInitializationFunctions tas.Type.initFunction |> List.choose( fun i_f -> i_f.initFunction) |> List.map(fun c -> c.def) |> Seq.StrJoin "\n" )
+                match r.callersSet |> Set.contains (f InitFunctionType) with
+                | true -> 
+                    match lm.lg.initMethod with
+                    | Procedure ->
+                        Some(getInitializationFunctions tas.Type.initFunction |> List.choose( fun i_f -> i_f.initProcedure) |> List.map(fun c -> c.def) |> Seq.StrJoin "\n" )
+                    | Function ->
+                        Some(getInitializationFunctions tas.Type.initFunction |> List.choose( fun i_f -> i_f.initFunction) |> List.map(fun c -> c.def) |> Seq.StrJoin "\n" )
+                | false -> None
+
             let init_globals    =
                 //we generate const globals only if requested by user and the init method is procedure
                 match r.args.generateConstInitGlobals && (lm.lg.initMethod  = Procedure) with
@@ -116,28 +123,32 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
 
 
             let equal_defs =
-                match r.args.GenerateEqualFunctions with
+                match r.args.GenerateEqualFunctions && (r.callersSet |> Set.contains (f EqualFunctionType)) with
                 | true  -> GetMySelfAndChildren tas.Type |> List.choose(fun t -> t.equalFunction.isEqualFuncDef )
                 | false -> []
             let isValidFuncs =
-                match tas.Type.isValidFunction with
-                | None      -> []
-                | Some f    ->
-                    getValidFunctions f |> List.choose(fun f -> f.funcDef)
+                match r.callersSet |> Set.contains (f IsValidFunctionType) with
+                | false -> []
+                | true  ->
+                    match tas.Type.isValidFunction with
+                    | None      -> []
+                    | Some f    ->
+                        getValidFunctions f |> List.choose(fun f -> f.funcDef)
 
 
-            let uPerEncFunc = match requiresUPER with true -> tas.Type.uperEncFunction.funcDef | false -> None
-            let uPerDecFunc = match requiresUPER with true -> tas.Type.uperDecFunction.funcDef | false -> None
+            let uPerEncFunc = match requiresUPER && r.callersSet |> Set.contains (f UperEncDecFunctionType) with true -> tas.Type.uperEncFunction.funcDef | false -> None
+            let uPerDecFunc = match requiresUPER && r.callersSet |> Set.contains (f UperEncDecFunctionType) with true -> tas.Type.uperDecFunction.funcDef | false -> None
 
             let xerEncFunc = match tas.Type.xerEncFunction with XerFunction z -> z.funcDef | XerFunctionDummy -> None
             let xerDecFunc = match tas.Type.xerDecFunction with XerFunction z -> z.funcDef | XerFunctionDummy -> None
 
+            let hasAcnEncDec = r.callersSet |> Set.contains (f AcnEncDecFunctionType)
             let acnEncFunc =
-                match requiresAcn, tas.Type.acnEncFunction with
+                match hasAcnEncDec && requiresAcn, tas.Type.acnEncFunction with
                 | true, Some x -> x.funcDef
                 | _  -> None
             let acnDecFunc =
-                match requiresAcn, tas.Type.acnDecFunction with
+                match hasAcnEncDec && requiresAcn, tas.Type.acnDecFunction with
                 | true, Some x -> x.funcDef
                 | _ -> None
 
@@ -176,11 +187,16 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
         let typeDefs =
             seq {
                 for tas in tases do
-                    if r.args.encodings |> Seq.exists ((=) CommonTypes.UPER) then
+                    let typeAssignmentInfo = tas.Type.id.tasInfo.Value
+                    let f cl = {Caller.typeId = typeAssignmentInfo; funcType = cl}
+                    let reqUPER = r.callersSet |> Set.contains (f UperEncDecFunctionType)
+                    let reqACN = r.callersSet |> Set.contains (f AcnEncDecFunctionType)
+
+                    if reqUPER && r.args.encodings |> Seq.exists ((=) CommonTypes.UPER) then
                         yield (tas.Type.uperEncDecTestFunc |> Option.map (fun z -> z.funcDef))
                     if r.args.encodings |> Seq.exists ((=) CommonTypes.XER) then
                         yield (tas.Type.xerEncDecTestFunc |> Option.map (fun z -> z.funcDef))
-                    if r.args.encodings |> Seq.exists ((=) CommonTypes.ACN) then
+                    if reqACN && r.args.encodings |> Seq.exists ((=) CommonTypes.ACN) then
                         yield (tas.Type.acnEncDecTestFunc |> Option.map (fun z -> z.funcDef))
                 } |> Seq.choose id |> Seq.toList
         let testcase_specFileName = Path.Combine(outDir, pu.testcase_specFileName)
@@ -190,17 +206,23 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
     //source file
     let arrsTypeAssignments =
         tases |> List.map(fun t ->
+            let typeAssignmentInfo = t.Type.id.tasInfo.Value
+            let f cl = {Caller.typeId = typeAssignmentInfo; funcType = cl}
+
             let privateDefinition =
                 match t.Type.typeDefinitionOrReference with
                 | TypeDefinition td -> td.privateTypeDefinition
                 | ReferenceToExistingDefinition _   -> None
 
             let initialize =
-                match lm.lg.initMethod with
-                | InitMethod.Procedure  ->
-                    Some(getInitializationFunctions t.Type.initFunction |> List.choose( fun i_f -> i_f.initProcedure) |> List.map(fun c -> c.body) |> Seq.StrJoin "\n" )
-                | InitMethod.Function  ->
-                    Some(getInitializationFunctions t.Type.initFunction |> List.choose( fun i_f -> i_f.initFunction) |> List.map(fun c -> c.body) |> Seq.StrJoin "\n" )
+                match r.callersSet |> Set.contains (f InitFunctionType) with
+                | true -> 
+                    match lm.lg.initMethod with
+                    | InitMethod.Procedure  ->
+                        Some(getInitializationFunctions t.Type.initFunction |> List.choose( fun i_f -> i_f.initProcedure) |> List.map(fun c -> c.body) |> Seq.StrJoin "\n" )
+                    | InitMethod.Function  ->
+                        Some(getInitializationFunctions t.Type.initFunction |> List.choose( fun i_f -> i_f.initFunction) |> List.map(fun c -> c.body) |> Seq.StrJoin "\n" )
+                | false -> None
 
             let init_globals    =
                 match r.args.generateConstInitGlobals  && (lm.lg.initMethod  = Procedure) with
@@ -212,18 +234,21 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
                 t.Type.initFunction.user_aux_functions |> List.map snd
 
             let eqFuncs =
-                match r.args.GenerateEqualFunctions with
+                match r.args.GenerateEqualFunctions && (r.callersSet |> Set.contains (f EqualFunctionType)) with
                 | true  -> GetMySelfAndChildren t.Type |> List.choose(fun y -> y.equalFunction.isEqualFunc)
                 | false -> []
 
             let isValidFuncs =
-                match t.Type.isValidFunction with
-                | None      -> []
-                | Some f    ->
-                    getValidFunctions f |> List.choose(fun f -> f.func)
+                match r.callersSet |> Set.contains (f IsValidFunctionType) with
+                | false -> []
+                | true  ->
+                    match t.Type.isValidFunction with
+                    | None      -> []
+                    | Some f    ->
+                        getValidFunctions f |> List.choose(fun f -> f.func)
 
             let uperEncDec =
-                if requiresUPER then
+                if requiresUPER && r.callersSet |> Set.contains (f UperEncDecFunctionType) then
                     ((t.Type.uperEncFunction.func |> Option.toList |> List.collect (fun f -> f :: t.Type.uperEncFunction.auxiliaries))) @
                     ((t.Type.uperDecFunction.func |> Option.toList |> List.collect (fun f ->  f :: t.Type.uperDecFunction.auxiliaries)))
                 else []
@@ -235,9 +260,10 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
                 (match t.Type.xerDecFunction with
                 | XerFunction z -> z.func |> Option.toList
                 | XerFunctionDummy -> [])
-
+            
+            let hasAcnEncDec = r.callersSet |> Set.contains (f AcnEncDecFunctionType)
             let ancEncDec =
-                if requiresAcn then
+                if requiresAcn && hasAcnEncDec then
                     (t.Type.acnEncFunction |> Option.toList |> List.collect (fun x -> (x.func |> Option.toList) @ x.auxiliaries)) @
                     (t.Type.acnDecFunction |> Option.toList |> List.collect (fun x -> (x.func |> Option.toList) @ x.auxiliaries))
                 else []
@@ -288,12 +314,16 @@ let private printUnit (r:DAst.AstRoot)  (lm:LanguageMacros) (encodings: CommonTy
         let encDecFuncs =
             seq {
                 for tas in tases do
+                    let typeAssignmentInfo = tas.Type.id.tasInfo.Value
+                    let f cl = {Caller.typeId = typeAssignmentInfo; funcType = cl}
+                    let reqUPER = r.callersSet |> Set.contains (f UperEncDecFunctionType)
+                    let reqACN = r.callersSet |> Set.contains (f AcnEncDecFunctionType)
 
-                    if r.args.encodings |> Seq.exists ((=) CommonTypes.UPER) then
+                    if reqUPER && r.args.encodings |> Seq.exists ((=) CommonTypes.UPER) then
                         yield (tas.Type.uperEncDecTestFunc |> Option.map (fun z -> z.func))
                     if r.args.encodings |> Seq.exists ((=) CommonTypes.XER) then
                         yield (tas.Type.xerEncDecTestFunc |> Option.map (fun z -> z.func))
-                    if r.args.encodings |> Seq.exists ((=) CommonTypes.ACN) then
+                    if reqACN && r.args.encodings |> Seq.exists ((=) CommonTypes.ACN) then
                         yield (tas.Type.acnEncDecTestFunc |> Option.map (fun z -> z.func))
                 } |> Seq.choose id |> Seq.toList
 

--- a/CommonTypes/CommonTypes.fs
+++ b/CommonTypes/CommonTypes.fs
@@ -1003,6 +1003,7 @@ type CommandLineSettings = {
     generateAcnIcd: bool
     custom_Stg_Ast_Version : int
     icdPdus : (string list) option
+    detectPdus : bool
     mappingFunctionsModule : string option
     integerSizeInBytes : BigInteger            //currently only the value of 4 or 8 bytes (32/64 bits) is supported
     floatingPointSizeInBytes : BigInteger       // 8 or 4

--- a/FrontEndAst/Asn1AcnAst.fs
+++ b/FrontEndAst/Asn1AcnAst.fs
@@ -670,6 +670,8 @@ type Asn1Type = {
     acnEncSpecPosition          : (SrcLoc*SrcLoc) option   //start pos, end pos
     acnEncSpecAntlrSubTree      : ITree option
     unitsOfMeasure : string option
+
+    referencedBy    : TypeAssignmentInfo list
 }
  with
     member this.externalDependencies: RelativePath list =
@@ -904,6 +906,7 @@ type AstRoot = {
     acnConstants : Map<string, BigInteger>
     args:CommandLineSettings
     acnParseResults:CommonTypes.AntlrParserResult list //used in ICDs to regenerate with colors the initial ACN input
+    allDependencies : (TypeAssignmentInfo*TypeAssignmentInfo) list      //caller, callee
 }
 
 
@@ -959,4 +962,5 @@ type Asn1AcnMergeState = {
     allocatedTypeNames          : Map<(ProgrammingLanguage*string), string list>      //language, type definition name, program unit lists 
     allocatedFE_TypeDefinition  : Map<(ProgrammingLanguage*ReferenceToType), FE_TypeDefinition>
     temporaryTypesAllocation    : Map<(ProgrammingLanguage*ReferenceToType), string>
+    allDependencies             : (TypeAssignmentInfo*TypeAssignmentInfo) list      //caller, callee
 }

--- a/FrontEndAst/DAst.fs
+++ b/FrontEndAst/DAst.fs
@@ -1024,6 +1024,7 @@ and Asn1Type = {
 
     Kind            : Asn1TypeKind
     unitsOfMeasure  : string option
+    referencedBy    : TypeAssignmentInfo list
 } with
     member this.toAsn1AcnAst: Asn1AcnAst.Asn1Type =
         {
@@ -1040,6 +1041,7 @@ and Asn1Type = {
             acnEncSpecPosition = None
             acnEncSpecAntlrSubTree = None
             unitsOfMeasure = this.unitsOfMeasure
+            referencedBy = this.referencedBy
         }
 
 

--- a/FrontEndAst/DAst.fs
+++ b/FrontEndAst/DAst.fs
@@ -90,21 +90,18 @@ type FunctionType =
     | InitFunctionType
     | IsValidFunctionType
     | EqualFunctionType
-    | UperEncFunctionType
-    | UperDecFunctionType
-    | AcnEncFunctionType
-    | AcnDecFunctionType
+    | UperEncDecFunctionType
+    | AcnEncDecFunctionType
 
 
 type Caller = {
-    typeId : ReferenceToType
+    typeId : TypeAssignmentInfo
     funcType : FunctionType
 }
 
 type Callee = {
-    typeId : ReferenceToType
+    typeId : TypeAssignmentInfo
     funcType : FunctionType
-    funcName : string
 }
 
 type State = {
@@ -1180,6 +1177,7 @@ type AstRoot = {
     lang         : ProgrammingLanguage
     acnParseResults:CommonTypes.AntlrParserResult list //used in ICDs to regenerate with collors the initial ACN input
     icdHashes   : Map<String, IcdTypeAss list>
+    callersSet  : Set<Caller>
 }
 
 

--- a/FrontEndAst/DAst.fs
+++ b/FrontEndAst/DAst.fs
@@ -92,6 +92,8 @@ type FunctionType =
     | EqualFunctionType
     | UperEncDecFunctionType
     | AcnEncDecFunctionType
+    | XerEncDecFunctionType
+    | BerEncDecFunctionType
 
 
 type Caller = {

--- a/FrontEndAst/LspAst.fs
+++ b/FrontEndAst/LspAst.fs
@@ -108,6 +108,7 @@ let defaultCommandLineSettings  =
         objectIdentifierMaxLength = 20I
         generateConstInitGlobals = false
         icdPdus = None
+        detectPdus = false
         handleEmptySequences = false
         blm = []
         userRtlFunctionsToGenerate= []

--- a/asn1scc/Program.fs
+++ b/asn1scc/Program.fs
@@ -33,7 +33,7 @@ type CliArguments =
     | [<Unique; AltCommandLine("-icdAcn")>] IcdAcn  of acn_icd_output_file:string
     | [<Unique; AltCommandLine("-customIcdAcn")>] CustomIcdAcn  of custom_stg_colon_out_filename:string
     | [<Unique; AltCommandLine("-icdPdus")>] IcdPdus  of asn1_type_assignments_list:string
-
+    | [<Unique; AltCommandLine("-dpdus")>] DetectPdus
     | [<Unique; AltCommandLine("-AdaUses")>] AdaUses
     | [<Unique; AltCommandLine("-ACND")>] ACND
     | [<Unique; AltCommandLine("-wordSize")>] Word_Size  of wordSize:int
@@ -102,6 +102,7 @@ E.g., -eee 50 will enable this mode for enumerated types with 50 or more enumera
             | CustomIcdUper  _  -> "Invokes the custom stg file 'stgFile.stg' using the icdUper backend and produces the output file 'outputFile'"
             | IcdAcn  _         -> "Produces an Interface Control Document for the input ASN.1 and ACN grammars for ACN encoding"
             | CustomIcdAcn  _   -> "Invokes the custom stg file 'stgFile.stg' using the icdAcn backend and produces the output file 'outputFile'"
+            | DetectPdus        -> "Automatically detects the Protocol Data Units (PDUs) in the input ASN.1 grammar and prints them to the console. PDUs are defined as top-level types, i.e., types that are not referenced by any other type."
             | IcdPdus       _   -> "A list of type assignments to be included in the generated ICD. If there are multiple type assignments, please separate them with commas and enclose them in double quotes."
             | AdaUses           -> "Prints in the console all type Assignments of the input ASN.1 grammar"
             | ACND              -> "creates ACN grammars for the input ASN.1 grammars using the default encoding properties"
@@ -256,6 +257,7 @@ let checkArgument (cliArgs : CliArguments list) arg =
     | IcdAcn  outHtmlFile       -> checkOutFileName outHtmlFile ".html" "-icdAcn"
     | CustomIcdAcn  comFile     -> checkCompositeFile comFile "-customIcdAcn" ".html"
     | IcdPdus _                 -> ()
+    | DetectPdus                -> ()
     | AdaUses                   -> ()
     | ACND                      -> ()
     | Debug_Asn1  _             -> ()
@@ -330,6 +332,7 @@ let constructCommandLineSettings args (parserResults: ParseResults<CliArguments>
                 // remove double quotes and split by comma
                 let actualPdus = pdus.Replace("\"", "")
                 Some ((actualPdus.Split(',')) |> Seq.map(fun (z:string) -> z.Trim()) |> Seq.filter(fun z -> not (String.IsNullOrEmpty z)) |> Seq.toList)
+        detectPdus = parserResults.Contains <@ DetectPdus @>
         mappingFunctionsModule = parserResults.TryGetResult(<@ Mapping_Functions_Module @>)
         integerSizeInBytes =
             let ws = parserResults.GetResult(<@Word_Size@>, defaultValue = 8)


### PR DESCRIPTION
This PR introduces functionality to **automatically detect and exclude unused generated functions**, resulting in significantly **smaller output code** for both C and Ada backends.

### Key Features

1. **Unused Function Elimination via `-icdPdus`**  
   When using the `-icdPdus` argument, ASN1SCC now performs a dependency analysis starting from the specified PDUs and their associated functions (`isEqual()`, `isValid()`, `init()`, `encode()`, and `decode()`).
   - Only the functions directly or indirectly required by these PDUs are generated.
   - All unused functions are excluded from the output, reducing code size and improving maintainability.

2. **New `-dpdus` Argument**  
   A new command-line option, `-dpdus`, was added to help identify Protocol Data Units (PDUs) in the input ASN.1 grammar.
   - PDUs are defined as top-level types that are not referenced by any other type.
   - Detected PDUs are printed to the console to help users configure `-icdPdus` more easily.

### Impact

- Reduces the size of generated code by omitting unused functions.
- Especially beneficial for resource-constrained systems or projects aiming to minimize binary size.

