### PR TITLE
Document the size property for booleans

### DIFF
--- a/Docs/ACN_V4.txt
+++ b/Docs/ACN_V4.txt
@@ -157,6 +157,9 @@ The following table lists the ASN.1 types where the fixed form can be applied as
 ! Asn1 Type
 ! Count unit of intExpr
 |-
+| Boolean
+| Bits
+|-
 | Integer
 | Bits
 |-


### PR DESCRIPTION
This is both a merge request and an issue report. I figured the `size` property would not be supported for BOOLEAN types, because it makes very limited sense. When I noted that no error is produced when you do use it (ASN.1: `MyBool ::= BOOLEAN`, ACN: `MyBool [size 3]`), I looked into the generated C code and saw that it would still only read/write a single bit. Next, I looked at the code in `FrontEndAst/AcnCreateFromAntlr.fs` and saw that there is some code to make the `size` property work.

In conclusion:
- The `size` property for `BOOLEAN` types is measured in bits (this MR).
- The implementation of the property does not function as intended.

Shall I open a separate issue for the second point?