### PR TITLE
GNAT 15: (style) bad casing of ASCII declared in Standard [-gnatyn] - patch #2

### DIFF
--- a/ADA_RTL2/src/adaasn1rtl.adb
+++ b/ADA_RTL2/src/adaasn1rtl.adb
@@ -9,7 +9,7 @@ is
    begin
       for i in str'Range loop
          pragma Loop_Invariant (length = length'Loop_Entry + (i - str'First));
-         exit when str (i) = Standard.Ascii.NUL;
+         exit when str (i) = Standard.ASCII.NUL;
          length := length + 1;
       end loop;
 


### PR DESCRIPTION
By accident I forgot to commit this one, it should really go to #378 