### PR TITLE
Fix ICD generation with --acn-v2 (#382)

### DIFF
--- a/BackendAst/Acn/AcnReference.fs
+++ b/BackendAst/Acn/AcnReference.fs
@@ -15,63 +15,62 @@ open AcnExternalField
 
 let emptyIcdFnc fieldName sPresent comments  = [],[]
 
-let createReferenceFunction_inline (r:Asn1AcnAst.AstRoot) (deps:Asn1AcnAst.AcnInsertedFieldDependencies) (lm:LanguageMacros) (codec:CommonTypes.Codec) (t:Asn1AcnAst.Asn1Type) (o:Asn1AcnAst.ReferenceType) (typeDefinition:TypeDefinitionOrReference) (isValidFunc: IsValidFunction option) (baseType:Asn1Type) (us:State)  =
-  let baseTypeDefinitionName, baseFncName = getBaseFuncName lm typeDefinition o t.id "_ACN" codec
-
-  //let td = lm.lg.getTypeDefinition t.FT_TypeDefinition
-  let getNewSType (r:IcdRow) =
-    (*
-    let newType =
-        match r.sType with
-        | TypeHash hash   -> TypeHash hash
-        | IcdPlainType plainType when r.rowType = FieldRow -> IcdPlainType (td.asn1Name + "(" + plainType + ")")
-        | IcdPlainType plainType -> IcdPlainType plainType
-    {r with sType = newType}
-    *)
-    r
-
-  let icdFnc,extraComment, name  =
-    match r.args.generateAcnIcd with
-    | true  ->
-        match o.encodingOptions with
-        | None ->
-            let name =
-              match o.hasExtraConstrainsOrChildrenOrAcnArgs with
-              | false -> None
-              | true -> Some t.id.AsString.RDD
-            match baseType.icdTas with
-            | Some baseTypeIcdTas ->
-                let icdFnc fieldName sPresent comments  =
-                    let rows, comp = baseTypeIcdTas.createRowsFunc fieldName sPresent comments
-                    rows |> List.map(fun r -> getNewSType r), comp
-
-                icdFnc, baseTypeIcdTas.comments, name
-            | None -> emptyIcdFnc, [], name
-
-        | Some encOptions ->
-            let lengthDetRow =
-                match encOptions.acnEncodingClass with
-                | SZ_EC_LENGTH_EMBEDDED  nSizeInBits ->
-                    let sCommentUnit = match encOptions.octOrBitStr with ContainedInOctString -> "bytes" | ContainedInBitString -> "bits"
-
-                    [ {IcdRow.fieldName = "Length"; comments = [$"The number of {sCommentUnit} used in the encoding"]; sPresent="always";sType=IcdPlainType "INTEGER"; sConstraint=None; minLengthInBits = nSizeInBits ;maxLengthInBits=nSizeInBits;sUnits=None; rowType = IcdRowType.LengthDeterminantRow; idxOffset = None}]
-                | _ -> []
-            match baseType.icdTas with
-            | Some baseTypeIcdTas ->
-                let icdFnc fieldName sPresent comments  =
-                    let rows0, compChildren = baseTypeIcdTas.createRowsFunc fieldName sPresent comments
-                    let rows = rows0 |> List.map getNewSType
-                    lengthDetRow@rows |> List.mapi(fun i r -> {r with idxOffset = Some (i+1)}), compChildren
-                icdFnc, ("OCTET STING CONTAINING BY"::baseTypeIcdTas.comments), Some (t.id.AsString.RDD + "_OCT_STR" )
-            | None -> emptyIcdFnc, [], None
-    | false -> emptyIcdFnc, [], None
-
-
-  let icd =
+// Construct the IcdArgAux that a reference type contributes to its parent's
+// ICD.  Delegates the row generation to baseType.icdTas, optionally prefixed
+// with a Length determinant row when the reference is a CONTAINING with
+// LENGTH_EMBEDDED encoding.  Shared between the legacy inline path
+// (createReferenceFunction_inline below) and the --acn-v2 deferred path
+// (DAstACNDeferred.fs).  Without this delegation the deferred path used to
+// emit None, which silently dropped every deferred reference (and all its
+// transitive dependents) from the generated _new.html ICD.
+let buildReferenceIcdArgAux
+        (r: Asn1AcnAst.AstRoot)
+        (t: Asn1AcnAst.Asn1Type)
+        (o: Asn1AcnAst.ReferenceType)
+        (baseType: Asn1Type) : IcdArgAux option =
+    let getNewSType (rw:IcdRow) = rw
+    let icdFnc, extraComment, name =
+        match r.args.generateAcnIcd with
+        | true  ->
+            match o.encodingOptions with
+            | None ->
+                let name =
+                    match o.hasExtraConstrainsOrChildrenOrAcnArgs with
+                    | false -> None
+                    | true  -> Some t.id.AsString.RDD
+                match baseType.icdTas with
+                | Some baseTypeIcdTas ->
+                    let icdFnc fieldName sPresent comments  =
+                        let rows, comp = baseTypeIcdTas.createRowsFunc fieldName sPresent comments
+                        rows |> List.map getNewSType, comp
+                    icdFnc, baseTypeIcdTas.comments, name
+                | None -> emptyIcdFnc, [], name
+            | Some encOptions ->
+                let lengthDetRow =
+                    match encOptions.acnEncodingClass with
+                    | SZ_EC_LENGTH_EMBEDDED nSizeInBits ->
+                        let sCommentUnit = match encOptions.octOrBitStr with ContainedInOctString -> "bytes" | ContainedInBitString -> "bits"
+                        [ {IcdRow.fieldName = "Length"; comments = [$"The number of {sCommentUnit} used in the encoding"]; sPresent="always";sType=IcdPlainType "INTEGER"; sConstraint=None; minLengthInBits = nSizeInBits ;maxLengthInBits=nSizeInBits;sUnits=None; rowType = IcdRowType.LengthDeterminantRow; idxOffset = None}]
+                    | _ -> []
+                match baseType.icdTas with
+                | Some baseTypeIcdTas ->
+                    let icdFnc fieldName sPresent comments  =
+                        let rows0, compChildren = baseTypeIcdTas.createRowsFunc fieldName sPresent comments
+                        let rows = rows0 |> List.map getNewSType
+                        lengthDetRow@rows |> List.mapi(fun i rw -> {rw with idxOffset = Some (i+1)}), compChildren
+                    icdFnc, ("OCTET STING CONTAINING BY"::baseTypeIcdTas.comments), Some (t.id.AsString.RDD + "_OCT_STR")
+                | None -> emptyIcdFnc, [], None
+        | false -> emptyIcdFnc, [], None
     match baseType.icdTas with
     | Some baseTypeIcdTas ->
         Some {IcdArgAux.canBeEmbedded = baseTypeIcdTas.canBeEmbedded; baseAsn1Kind = (getASN1Name t); rowsFunc = icdFnc; commentsForTas=extraComment; scope="REFTYPE"; name=name}
     | None -> None
+
+
+let createReferenceFunction_inline (r:Asn1AcnAst.AstRoot) (deps:Asn1AcnAst.AcnInsertedFieldDependencies) (lm:LanguageMacros) (codec:CommonTypes.Codec) (t:Asn1AcnAst.Asn1Type) (o:Asn1AcnAst.ReferenceType) (typeDefinition:TypeDefinitionOrReference) (isValidFunc: IsValidFunction option) (baseType:Asn1Type) (us:State)  =
+  let baseTypeDefinitionName, baseFncName = getBaseFuncName lm typeDefinition o t.id "_ACN" codec
+
+  let icd = buildReferenceIcdArgAux r t o baseType
 
   match o.encodingOptions with
   | None          ->

--- a/BackendAst/DAstACNDeferred.fs
+++ b/BackendAst/DAstACNDeferred.fs
@@ -284,6 +284,16 @@ let private createDeferredSequenceFunction
                                                 lm.acn.acn_deferred_det_init_ptr initFuncName detVarName innerCodec
                                             else
                                                 lm.acn.acn_deferred_det_init_value initFuncName detVarName innerCodec
+                                    // Borrow the original encode body's icd
+                                    // entry so the determinant still shows up
+                                    // as a row in the parent SEQUENCE's ICD —
+                                    // the wire format is unchanged (still N
+                                    // bits at the same position), only the
+                                    // computation timing differs (InitDet
+                                    // reserves, PatchDet fills in later).
+                                    let originalIcd =
+                                        originalFuncBody innerCodec acnArgs nestingScope p bsPos
+                                        |> Option.bind (fun r -> r.icdResult)
                                     Some {
                                         AcnFuncBodyResult.funcBody = initCode
                                         errCodes = []
@@ -294,7 +304,7 @@ let private createDeferredSequenceFunction
                                         bBsIsUnReferenced = false
                                         resultExpr = None
                                         auxiliaries = []
-                                        icdResult = None
+                                        icdResult = originalIcd
                                         userDefinedFunctions = []
                                     }
                                 | CommonTypes.Codec.Decode ->
@@ -529,6 +539,13 @@ type private DeferredRefCtx = {
     o:              Asn1AcnAst.ReferenceType
     typeDefinition: TypeDefinitionOrReference
     isValidFunc:    IsValidFunction option
+    // ICD contribution this reference owes to its parent SEQUENCE/CHOICE.
+    // Built from baseType.icdTas the same way the legacy inline path does
+    // (see AcnReference.buildReferenceIcdArgAux).  Threading it through the
+    // deferred path is what keeps the generated _new.html ICD complete in
+    // --acn-v2 mode; without it every closure-converted reference (and
+    // everything reachable only through one) disappears from the document.
+    refIcd:         IcdArgAux option
 }
 
 
@@ -857,7 +874,7 @@ let private buildCallerWrapper
                bBsIsUnReferenced = false
                resultExpr = resultExpr
                auxiliaries = allAuxiliaries
-               icdResult = None}), callerUs
+               icdResult = ctx.refIcd}), callerUs
 
     // Record the function-call dependency (caller → callee)
     let ns3 =
@@ -892,6 +909,12 @@ let private createDeferredReferenceFunction
 
     let _baseTypeDefinitionName, baseFncName = getBaseFuncName lm typeDefinition o t.id "_ACN" codec
 
+    // ICD this reference contributes to its parent.  Same construction as the
+    // legacy inline path; without it the parent SEQUENCE drops the field row
+    // for this reference, breaks the TypeHash row chain, and
+    // GenerateAcnIcd.getMySelfAndChildren never reaches the resolved type.
+    let refIcd = AcnReference.buildReferenceIcdArgAux r t o baseType
+
     let isContainingExternalField =
         match o.encodingOptions with
         | Some enc -> match enc.acnEncodingClass, enc.octOrBitStr with
@@ -919,21 +942,21 @@ let private createDeferredReferenceFunction
             | Asn1AcnAst.SZ_EC_FIXED_SIZE, CommonTypes.ContainedInOctString ->
                 Some (makeContainingFuncBody (fun pp fncName ->
                     let fncBody = lm.acn.octet_string_containing_deferred_fixed_func pp fncName codec
-                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = None}), us))
+                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = refIcd}), us))
             | Asn1AcnAst.SZ_EC_LENGTH_EMBEDDED _, CommonTypes.ContainedInOctString ->
                 Some (makeContainingFuncBody (fun pp fncName ->
                     let nBits = GetNumberOfBitsForNonNegativeInteger (encOptions.maxSize.acn - encOptions.minSize.acn)
                     let fncBody = lm.acn.octet_string_containing_deferred_embedded_func pp fncName encOptions.minSize.acn encOptions.maxSize.acn nBits codec
-                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = None}), us))
+                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = refIcd}), us))
             | Asn1AcnAst.SZ_EC_FIXED_SIZE, CommonTypes.ContainedInBitString ->
                 Some (makeContainingFuncBody (fun pp fncName ->
                     let fncBody = lm.acn.bit_string_containing_deferred_fixed_func pp fncName codec
-                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = None}), us))
+                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = refIcd}), us))
             | Asn1AcnAst.SZ_EC_LENGTH_EMBEDDED _, CommonTypes.ContainedInBitString ->
                 Some (makeContainingFuncBody (fun pp fncName ->
                     let nBits = GetNumberOfBitsForNonNegativeInteger (encOptions.maxSize.acn - encOptions.minSize.acn)
                     let fncBody = lm.acn.bit_string_containing_deferred_embedded_func pp fncName encOptions.minSize.acn encOptions.maxSize.acn nBits codec
-                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = None}), us))
+                    Some ({AcnFuncBodyResult.funcBody = fncBody; errCodes = []; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=None; auxiliaries=[]; icdResult = refIcd}), us))
             | _ when not isContainingExternalField ->
                 Some (DAstACN.createReferenceFunction_inline r deps lm codec t o typeDefinition isValidFunc baseType us)
             | _ -> None  // ExternalField with params → specialized function below
@@ -990,6 +1013,7 @@ let private createDeferredReferenceFunction
                 o              = o
                 typeDefinition = typeDefinition
                 isValidFunc    = isValidFunc
+                refIcd         = refIcd
             }
 
             // Generate body content — dispatched on the 3-way match.  Each branch


### PR DESCRIPTION
## Summary

- Fixes #382: with `--acn-v2`, the generated `*_new.html` ICD was missing every closure-converted reference, every ACN-inserted determinant promoted to InitDet/PatchDet, and all transitively reachable dependent types
- Extracts the legacy reference-icd builder into a public helper (`AcnReference.buildReferenceIcdArgAux`) and reuses it from `DAstACNDeferred.fs` at five sites (`buildCallerWrapper` + four CONTAINING earlyReturn branches)
- For the synthetic InitDet encode body, borrows the icd entry from the original AcnChild's encode funcBody — the wire format is unchanged (still N bits at the same position)

## Test plan

- [x] Maxime's reproducer (4 PDUs across `OBC-ASW` + `ccsds-space-packet`): `_new.html` now has 143 tables (vs 4 broken / 142 legacy), all 4 root PDUs have their full field rows, all dependent types appear
- [x] Without `--acn-v2`: generated ICD is byte-identical pre/post fix; anchor hashes stable
- [x] `acnv2/01, 01b, 02, 02b, 03, 03b, 04, 04b, 05, 05b, 06, 06b, 10` — all build + `make coverage` match the baselines in `q/details-docs/acn-v2-done.md`
- [x] `runTests.py -l c --acn-v2 -t 14-RealCases/02-PUS.asn1` — 10/10 succeed, 100% coverage on `sample1.c`