### PR TITLE
Reject ACN size smaller than ceil(log2(N)) for ENUMERATED (#384)

### DIFF
--- a/FrontEndAst/AcnCreateFromAntlr.fs
+++ b/FrontEndAst/AcnCreateFromAntlr.fs
@@ -787,6 +787,11 @@ let private mergeEnumerated (asn1: Asn1Ast.AstRoot) (lms:(ProgrammingLanguage*La
     let alignment = tryGetProp props (fun x -> match x with ALIGNTONEXT e -> Some e | _ -> None)
     let acnEncodingClass,  acnMinSizeInBits, acnMaxSizeInBits= AcnEncodingClasses.GetEnumeratedEncodingClass asn1.args.integerSizeInBytes items alignment loc acnProperties uperSizeInBits uperSizeInBits encodeValues
 
+    let acnErrLoc0 = match acnErrLoc with Some a -> a | None -> loc
+    let enumMinVal = items |> List.map(fun x -> x.acnEncodeValue) |> List.min
+    let enumMaxVal = items |> List.map(fun x -> x.acnEncodeValue) |> List.max
+    checkIntHasEnoughSpace acnEncodingClass false acnErrLoc0 enumMinVal enumMaxVal
+
     let validItems = items |> List.filter (Asn1Fold.isValidValueGeneric cons (fun a b -> a = b.Name.Value)) |> List.sortBy(fun x -> x.definitionValue)
 
     match validItems with

--- a/v4Tests/test-cases/acn/04-ENUMERATED/001.asn1
+++ b/v4Tests/test-cases/acn/04-ENUMERATED/001.asn1
@@ -19,6 +19,7 @@ END
 --TCLS     MyPDU[] { alpha[50], beta[60] }
 
 --TCLS     MyPDU[encode-values, encoding pos-int, size 10]
+--TCLFC    MyPDU[encode-values, encoding pos-int, size 7]	$$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 127 to be encoded, while the corresponding ASN.1 type allows values up to 200
 --TCLFC     MyPDU[encode-values, encoding twos-complement, size 10]	$$$ sample1.asn1:4:11: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encode-values, encoding BCD, size 12]
 --  TCLS     MyPDU[encode-values, encoding BCD, size null-terminated]

--- a/v4Tests/test-cases/acn/04-ENUMERATED/004.asn1
+++ b/v4Tests/test-cases/acn/04-ENUMERATED/004.asn1
@@ -1,0 +1,14 @@
+-- NOCOVERAGE RUN_SPARK
+TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
+
+	MyPDU ::= ENUMERATED {
+		one, two, three, four
+	}
+
+	pdu1 MyPDU ::= one
+
+END
+
+--TCLFC    MyPDU[encoding pos-int, size 1]   $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 1 to be encoded, while the corresponding ASN.1 type allows values up to 3
+--TCLS     MyPDU[encoding pos-int, size 2]
+--TCLS     MyPDU[encoding pos-int, size 8]


### PR DESCRIPTION
## Summary

- Fixes #384: ACN size smaller than `ceil(log2(N))` for an `ENUMERATED` with `N` enumerants was accepted silently, producing a truncating encoder
- Adds the missing call to the existing `checkIntHasEnoughSpace` predicate from `mergeEnumerated` (frontend, so the error is language-independent and fires symmetrically with `--acn-v2`)
- The predicate uses the min/max of `items[].acnEncodeValue`, so it covers both the implicit (`0..N-1`) and explicit (`encode-values`) value sets, across `pos-int`, `twos-complement`, `BCD`, `ASCII`

## Test plan

- [x] Reproducer (`E ::= ENUMERATED { one, two, three, four }` + `E [size 1, encoding pos-int]`) now fails: `error: The applied ACN encoding does not allow values larger than 1 to be encoded, while the corresponding ASN.1 type allows values up to 3`
- [x] Same grammar with `size 2` still succeeds (boundary)
- [x] Same reproducer with `--acn-v2`: same error (frontend check, language-independent)
- [x] `v4Tests/test-cases/acn/04-ENUMERATED/004.asn1` (new) — `size 1` fails, `size 2` and `size 8` pass
- [x] `v4Tests/test-cases/acn/04-ENUMERATED/001.asn1` — appended a `--TCLFC` for `encode-values, size 7` with explicit value 200 → fails as expected
- [x] Full C regression: 383/383 OK
- [x] Full C regression with `--acn-v2`: 383/383 OK
- [x] Ada 04-ENUMERATED subset: 26/26 OK (pre-existing SPARK toolchain failures elsewhere are unrelated)
