### PR TITLE
Fix REAL constraints missing from new ICD (#387)

### DIFF
--- a/BackendAst/Acn/AcnPrimitives.fs
+++ b/BackendAst/Acn/AcnPrimitives.fs
@@ -219,6 +219,11 @@ let createRealFunction (r:Asn1AcnAst.AstRoot) (deps: Asn1AcnAst.AcnInsertedField
         | ASN1SCC_FP32   -> "_fp32"
         | ASN1SCC_FP64   -> ""
 
+    let sAsn1Constraints =
+        let sTmpCons = o.AllCons |> List.map (DastValidate2.printRangeConAsAsn1 (fun z -> z.ToString())) |> Seq.StrJoin ""
+        match sTmpCons.Trim() with
+        | "" -> None
+        | _  -> Some sTmpCons
 
     let funcBody (errCode:ErrorCode) (acnArgs: (AcnGenericTypes.RelativePath*AcnGenericTypes.AcnParameter) list) (nestingScope: NestingScope) (p:CodegenScope) =
         let pp, resultExpr = adaptArgument lm codec p
@@ -235,7 +240,7 @@ let createRealFunction (r:Asn1AcnAst.AstRoot) (deps: Asn1AcnAst.AcnInsertedField
         | None -> None
         | Some (funcBodyContent,errCodes, auxiliaries) ->
             let icdFnc fieldName sPresent comments =
-                [{IcdRow.fieldName = fieldName; comments = comments; sPresent=sPresent;sType=(IcdPlainType (getASN1Name t)); sConstraint=None; minLengthInBits = o.acnMinSizeInBits ;maxLengthInBits=o.acnMaxSizeInBits;sUnits=t.unitsOfMeasure; rowType = IcdRowType.FieldRow; idxOffset = None}], []
+                [{IcdRow.fieldName = fieldName; comments = comments; sPresent=sPresent;sType=(IcdPlainType (getASN1Name t)); sConstraint=sAsn1Constraints; minLengthInBits = o.acnMinSizeInBits ;maxLengthInBits=o.acnMaxSizeInBits;sUnits=t.unitsOfMeasure; rowType = IcdRowType.FieldRow; idxOffset = None}], []
             let icd = {IcdArgAux.canBeEmbedded = true; baseAsn1Kind = (getASN1Name t); rowsFunc = icdFnc; commentsForTas=[]; scope="type"; name= None}
 
             Some ({AcnFuncBodyResult.funcBody = funcBodyContent; errCodes = errCodes; localVariables = []; userDefinedFunctions=[]; bValIsUnReferenced= false; bBsIsUnReferenced=false; resultExpr=resultExpr; auxiliaries=auxiliaries; icdResult=Some icd})


### PR DESCRIPTION
Fixes #387.

## Problem
The new ICD output (`*_new.html`) showed `N.A.` for ASN.1 constraints on REAL types, while the legacy ICD showed them correctly.

## Fix
`createRealFunction` in `BackendAst/Acn/AcnPrimitives.fs` was hardcoding `sConstraint=None` when building the `IcdRow`. Now it builds `sAsn1Constraints` from `o.AllCons` the same way `createIntegerFunction` does.

## Test
Tested locally with a simple grammar:
```asn1
MyReal ::= REAL (10.0 .. 30.0)
```
Before: constraint column shows `N.A.`
After: constraint column shows `(10 .. 30)`, matching the legacy ICD.