### PR TITLE
Fix parseStg2 build order dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1420,3 +1420,5 @@ asn1scc/Properties/launchSettings_UPER.json
 /dotnet-debian.SENTINEL
 /.claude/settings.local.json
 acnv2/*
+
+.fake

--- a/CommonTypes/CommonTypes.fsproj
+++ b/CommonTypes/CommonTypes.fsproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\parseStg2\parseStg2.csproj" />
+    <ProjectReference Include="..\parseStg2\parseStg2.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,7 +48,7 @@
     <PackageReference Update="FSharp.Core" Version="9.0.300-beta.25079.4" />
   </ItemGroup>
 
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	<Target Name="GenerateStringTemplates" BeforeTargets="CoreCompile">
 		<Exec Command="dotnet ../parseStg2/bin/$(ConfigurationName)/$(TargetFramework)/parseStg2.dll ../StgScala/backends.xml 4 AbstractMacros.fs" WorkingDirectory="$(ProjectDir)" />
 	</Target>
 

--- a/StgAda/StgAda.fsproj
+++ b/StgAda/StgAda.fsproj
@@ -73,6 +73,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\parseStg2\parseStg2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\FrontEndAst\FrontEndAst.fsproj" />
     <ProjectReference Include="..\ST\ST.fsproj" />
   </ItemGroup>
@@ -97,7 +98,7 @@
 	</ItemGroup>
 
 
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	<Target Name="GenerateStringTemplates" BeforeTargets="CoreCompile">
         <Exec Command="dotnet ../parseStg2/bin/$(ConfigurationName)/$(TargetFramework)/parseStg2.dll backends.xml 3" WorkingDirectory="$(ProjectDir)" />
     </Target>
 

--- a/StgC/StgC.fsproj
+++ b/StgC/StgC.fsproj
@@ -73,6 +73,7 @@
   </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\parseStg2\parseStg2.csproj" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\FrontEndAst\FrontEndAst.fsproj" />
         <ProjectReference Include="..\StgVarious\StgVarious.fsproj" />
         <ProjectReference Include="..\ST\ST.fsproj" />
@@ -98,7 +99,7 @@
 	</ItemGroup>
 
 
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	<Target Name="GenerateStringTemplates" BeforeTargets="CoreCompile">
         <Exec Command="dotnet ../parseStg2/bin/$(ConfigurationName)/$(TargetFramework)/parseStg2.dll backends.xml 3" WorkingDirectory="$(ProjectDir)" />
     </Target>
 

--- a/StgScala/StgScala.fsproj
+++ b/StgScala/StgScala.fsproj
@@ -71,6 +71,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\parseStg2\parseStg2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\CommonTypes\CommonTypes.fsproj" />
     <ProjectReference Include="..\FrontEndAst\FrontEndAst.fsproj" />
     <ProjectReference Include="..\StgVarious\StgVarious.fsproj" />
@@ -93,7 +94,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="9.0.300-beta.25079.4" />
   </ItemGroup>
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="GenerateStringTemplates" BeforeTargets="CoreCompile">
     <Exec Command="dotnet ../parseStg2/bin/$(ConfigurationName)/$(TargetFramework)/parseStg2.dll backends.xml 3" WorkingDirectory="$(ProjectDir)" />
   </Target>
 </Project>

--- a/StgVarious/StgVarious.fsproj
+++ b/StgVarious/StgVarious.fsproj
@@ -40,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\parseStg2\parseStg2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ST\ST.fsproj" />
   </ItemGroup>
 
@@ -47,7 +48,7 @@
     <PackageReference Update="FSharp.Core" Version="9.0.300-beta.25079.4" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="GenerateStringTemplates" BeforeTargets="CoreCompile">
     <Exec Command="dotnet ../parseStg2/bin/$(ConfigurationName)/$(TargetFramework)/parseStg2.dll backends.xml" WorkingDirectory="$(ProjectDir)" />
   </Target>
 

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -56,21 +56,14 @@ cd c:\asn1scc
 ```
 
 asn1scc generates some of its source code at build time with two helper tools (`Antlr`
-and `parseStg2`). Those tools must be built **first**, otherwise the main build fails
-with an error like
-`The command "dotnet ../parseStg2/.../parseStg2.dll ..." exited with code 1`.
-This is just a build-ordering requirement — the project's own build scripts do exactly
-the same thing. Build the two helpers, then the server, all in the **same configuration**
-(here, `Release`):
+and `parseStg2`). They are project dependencies and are built automatically in the same
+configuration as the server (here, `Release`):
 
 ```bat
-dotnet build Antlr\ -c Release
-dotnet build parseStg2\ -c Release
 dotnet build lsp\Server\Server\Server.csproj -c Release
 ```
 
-> Tip: building the whole solution once with `dotnet build asn1scc.sln -c Release` (after
-> the two helper builds above) also works and produces the server, but it builds the
+> Tip: `dotnet build asn1scc.sln -c Release` also produces the server, but it builds the
 > entire compiler, so it takes longer.
 
 The build produces the server here:
@@ -175,7 +168,6 @@ variable to log to a different directory.
 
 | Symptom | Likely cause / fix |
 |---------|--------------------|
-| Build fails with `... parseStg2.dll ... exited with code 1` | You skipped the helper builds. Build `Antlr\` and `parseStg2\` first, in the same configuration, then rebuild (see §2). |
 | Server won't start | .NET 10 SDK/runtime not installed, or wrong path in the editor config. Run the `dotnet ...Server.dll` command from §2 in a terminal to check it launches. |
 | No diagnostics or completion | Wrong server path, or the file extension isn't registered. Check the editor's LSP/Output log. In VSCode confirm the `asn1scc.languageServer.path` setting. |
 | Completion seems to ignore ACN settings | The server auto-loads the matching `.asn`/`.acn` file next to the open one — keep both in the same folder. |


### PR DESCRIPTION
This PR fixes a build ordering issue that could occur during a clean solution build.

Previously, several projects could invoke parseStg2 before the tool had been built, causing build failures on a fresh checkout. This change ensures that parseStg2 is built before it is required by dependent projects.

Changes:
- Added explicit project dependencies on parseStg2
- Updated build targets to enforce the correct build order
- Removed the need for manual pre-build workarounds
- Updated related build documentation
- Verified successful clean Release builds from a fresh checkout

Validation:
- dotnet build asn1scc.sln -c Release --no-restore
- Build completed successfully with no errors